### PR TITLE
fix(SAMS-51): Add youtube `frame-src` in CSP

### DIFF
--- a/src/_includes/layouts/base.liquid
+++ b/src/_includes/layouts/base.liquid
@@ -4,7 +4,7 @@
     {% if env.isProduction %}
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; connect-src 'self'; img-src 'self' https://piwik.technologiestiftung-berlin.de; script-src 'self' https://piwik.technologiestiftung-berlin.de; style-src 'self'; font-src 'self'; manifest-src 'self'; object-src 'none'; frame-src youtube.com www.youtube.com www.youtube-nocookie.com;"
+      content="default-src 'none'; connect-src 'self'; img-src 'self' https://piwik.technologiestiftung-berlin.de https://i.ytimg.com; script-src 'self' https://piwik.technologiestiftung-berlin.de; style-src 'self'; font-src 'self'; manifest-src 'self'; object-src 'none'; frame-src youtube.com www.youtube.com www.youtube-nocookie.com;"
     />
     {% endif %}
     <meta charset="UTF-8" />

--- a/src/_includes/layouts/base.liquid
+++ b/src/_includes/layouts/base.liquid
@@ -4,7 +4,7 @@
     {% if env.isProduction %}
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; connect-src 'self'; img-src 'self' https://piwik.technologiestiftung-berlin.de; script-src 'self' https://piwik.technologiestiftung-berlin.de; style-src 'self'; font-src 'self'; manifest-src 'self'; object-src 'none'; frame-src youtube.com www.youtube.com;"
+      content="default-src 'none'; connect-src 'self'; img-src 'self' https://piwik.technologiestiftung-berlin.de; script-src 'self' https://piwik.technologiestiftung-berlin.de; style-src 'self'; font-src 'self'; manifest-src 'self'; object-src 'none'; frame-src youtube.com www.youtube.com www.youtube-nocookie.com;"
     />
     {% endif %}
     <meta charset="UTF-8" />

--- a/src/_includes/layouts/base.liquid
+++ b/src/_includes/layouts/base.liquid
@@ -4,7 +4,7 @@
     {% if env.isProduction %}
     <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'none'; connect-src 'self'; img-src 'self' https://piwik.technologiestiftung-berlin.de; script-src 'self' https://piwik.technologiestiftung-berlin.de; style-src 'self'; font-src 'self'; manifest-src 'self'; object-src 'none'"
+      content="default-src 'none'; connect-src 'self'; img-src 'self' https://piwik.technologiestiftung-berlin.de; script-src 'self' https://piwik.technologiestiftung-berlin.de; style-src 'self'; font-src 'self'; manifest-src 'self'; object-src 'none'; frame-src youtube.com www.youtube.com;"
     />
     {% endif %}
     <meta charset="UTF-8" />


### PR DESCRIPTION
This PR adds a few URLs to `img-src` (video preview) and `frame-src` (video iframe) into the CSP to allow our youtube video to be displayed.