### PR TITLE
fix(header): prevent horizontal overflow

### DIFF
--- a/src/_includes/partials/footer.liquid
+++ b/src/_includes/partials/footer.liquid
@@ -41,7 +41,7 @@
     </div>
     <section class="container mt-0 px-4 flex justify-between flex-wrap">
       <span>© 2022 Technologiestiftung Berlin</span>
-      <ul class="flex gap-2 sm:gap-4">
+      <ul class="block sm:flex gap-2 sm:gap-4 flex-wrap">
         <li><a targe="_blank" rel="noopener noreferrer" href="mailto:info@citylab-berlin.org">Kontakt</a></li>
         <li><a targe="_blank" rel="noopener noreferrer" href="https://github.com/technologiestiftung/service-agentinnen">Quellcode</a></li>
         <li><a targe="_blank" rel="noopener noreferrer" href="mailto:info@citylab-berlin.org">Probleme der Barrierfreiheit melden</a></li>

--- a/src/_includes/partials/header.liquid
+++ b/src/_includes/partials/header.liquid
@@ -1,5 +1,5 @@
 <header
-  class="sticky z-10 top-0 w-screen bg-blue-500 text-white border-b border-blue-300 pt-3 pb-4"
+  class="sticky z-10 top-0 w-full bg-blue-500 text-white border-b border-blue-300 pt-3 pb-4"
 >
   <section class="px-4 container max-w-7xl flex justify-between items-center">
     <a


### PR DESCRIPTION
This PR updates the width of the header from `w-screen` to `w-full`. This prevents the subtle horizontal overflow that is occurring at the moment.