### PR TITLE
fix(SAMS-56): Make sure image and text don't overlap when no hypotheses

### DIFF
--- a/src/_includes/partials/module_hero.liquid
+++ b/src/_includes/partials/module_hero.liquid
@@ -27,7 +27,7 @@
     <img
       src="{{ hero_image_url }}"
       alt="{{ hero_image_alt }}"
-      class="translate-y-1/3 -mt-[50%]"
+      class="translate-y-12 {% if hypotheses %} sm:translate-y-1/3 {% else %} sm:translate-y-24 {% endif %} -mt-[50%]"
     />
   </div>
 </section>

--- a/src/_includes/partials/module_intro_hypotheses.liquid
+++ b/src/_includes/partials/module_intro_hypotheses.liquid
@@ -1,10 +1,6 @@
 {% if hypotheses %}
 <div
-<<<<<<< Updated upstream
-  class="container max-w-7xl px-4 py-2 sm:py-6 md:py-6 grid grid-cols-2 gap-4 sm:gap-8 md:gap-16"
-=======
-  class="container px-4 py-2 sm:py-6 md:py-6 grid sm:grid-cols-2 gap-4 sm:gap-8 md:gap-16"
->>>>>>> Stashed changes
+  class="container max-w-7xl px-4 py-2 sm:py-6 md:py-6 grid sm:grid-cols-2 gap-4 sm:gap-8 md:gap-16"
 >
   <ul>
     {% for link in hypotheses %}

--- a/src/_includes/partials/module_intro_hypotheses.liquid
+++ b/src/_includes/partials/module_intro_hypotheses.liquid
@@ -1,6 +1,10 @@
 {% if hypotheses %}
 <div
+<<<<<<< Updated upstream
   class="container max-w-7xl px-4 py-2 sm:py-6 md:py-6 grid grid-cols-2 gap-4 sm:gap-8 md:gap-16"
+=======
+  class="container px-4 py-2 sm:py-6 md:py-6 grid sm:grid-cols-2 gap-4 sm:gap-8 md:gap-16"
+>>>>>>> Stashed changes
 >
   <ul>
     {% for link in hypotheses %}


### PR DESCRIPTION
This PR Makes the image in a module hero displayed higher when there are no hypotheses to avoid overlap between text and image. See:

![Uploading Screenshot 2022-03-21 at 12.12.39.png…]()
 