### PR TITLE
style: fine-tune line-height of number in module card

### DIFF
--- a/src/_includes/partials/module_card.liquid
+++ b/src/_includes/partials/module_card.liquid
@@ -22,7 +22,7 @@
         class="text-xl md:text-lg xl:text-2xl md:leading-relaxed lg:leading-normal text-blue-500"
       >
         <span
-          class="text-[40px] md:text-[44px] xl:text-[64px] md:leading-3 lg:leading-none font-bold text-magenta-500"
+          class="text-[40px] md:text-[44px] xl:text-[60px] leading-[0.5] md:leading-[0.7] lg:leading-[0.6] xl:leading-[0.5] font-bold text-magenta-500"
         >
           {% if number < 10 %}0{% endif %}{{ number }}</span
         ><br />


### PR DESCRIPTION
This PR improves the line-height of the number in the module cards. On all breakpoints the number element occupies a bit less vertical space now.

<details>
<summary>See here the new line-heights for several screen sizes:</summary>

![Screenshot 2022-03-22 at 09 51 27](https://user-images.githubusercontent.com/15640196/159442984-790d9a30-894d-48d2-8096-7b26402623a6.png)

![Screenshot 2022-03-22 at 09 51 57](https://user-images.githubusercontent.com/15640196/159443013-2b0bf1fb-809f-4f6f-8e5d-d9137d27e64d.png)

![Screenshot 2022-03-22 at 09 52 10](https://user-images.githubusercontent.com/15640196/159443024-cf41e078-97c8-4292-add5-900a8a61ddd0.png)

![Screenshot 2022-03-22 at 09 52 21](https://user-images.githubusercontent.com/15640196/159443043-c504e0dc-2d5e-482a-8e40-c5765f3340b8.png)
</details>


