### PR TITLE
chore(SAMS-41): update base url

### DIFF
--- a/src/_data/site.json
+++ b/src/_data/site.json
@@ -1,6 +1,6 @@
 {
   "name": "ServiceAgent:innen",
-  "url": "https://serviceagentinnen.citylab-berlin.org",
+  "url": "https://service-agentinnen.citylab-berlin.org",
   "authorName": "CityLAB Berlin",
   "description": "ServiceAgent:innen ist eine Schulung zur agileren Arbeit in Behörden. Sie besteht aus acht Modulen.",
   "socialMediaImagePath": "/assets/images/home-social-image.webp",


### PR DESCRIPTION
This PR updates the base URL so that all URLs are constructed using our newly added CityLAB subdomain.