### PR TITLE
style(SAMS-71): use 1 column on small screens

### DIFF
--- a/src/_includes/partials/in_practice.liquid
+++ b/src/_includes/partials/in_practice.liquid
@@ -2,21 +2,27 @@
   class="container max-w-7xl py-8 px-8 bg-blue-50 bg-opacity-50 grid grid-cols-3 md:grid-cols-12 gap-8 mt-4 sm:mt-8 md:mt-16"
   aria-label="Abschnitt “In der Praxis”"
 >
-  <div class="col-span-2 md:col-span-8 lg:col-span-4 order-first md:order-none" aria-label="Einführung vom Abschnitt “In der Praxis”">
+  <div
+    class="col-span-3 sm:col-span-2 md:col-span-8 lg:col-span-4 order-first md:order-none"
+    aria-label="Einführung vom Abschnitt “In der Praxis”"
+  >
     {% include 'partials/heading.liquid' content: 'In der Praxis: Die
     Pilot-Schulung 2021' class: 'pb-3 sm:pb-5 text-magenta-500 max-w-prose' %}
     <p class="max-w-prose">
       Die Weiterbildung <i>Service:Agentinnen</i> ist ein vom CityLAB
       durchgeführtes Pilotprojekt. 16 Mitarbeiter:innen der Berliner Senats- und
-      Bezirksverwaltung haben an realen Verwaltungs&shy;prozessen die Prinzipien und
-      Werkzeuge der nutzer:innen&shy;zentrierten Prozessgestaltung erlernt.
+      Bezirksverwaltung haben an realen Verwaltungs&shy;prozessen die Prinzipien
+      und Werkzeuge der nutzer:innen&shy;zentrierten Prozessgestaltung erlernt.
     </p>
   </div>
   {% include 'partials/picture.liquid' directory: 'assets/images/' file_name:
   'schulung' image_alt: 'Ein Laptop, auf dem die Schulung über Zoom stattfindet'
-  width: '800' height: '384' sizes: '400 600 800' class: 'col-span-1 md:col-start-9
-  md:col-span-4 w-full aspect-auto' %}
-  <div class="col-span-3 md:col-span-12" aria-label="Abschnitt mit O-Tönen unserer Teilnehmer:innen">
+  width: '800' height: '384' sizes: '400 600 800' class: 'col-span-3
+  sm:col-span-1 md:col-start-9 md:col-span-4 w-full aspect-auto' %}
+  <div
+    class="col-span-3 md:col-span-12"
+    aria-label="Abschnitt mit O-Tönen unserer Teilnehmer:innen"
+  >
     <h3 class="text-lg sm:text-xl md:text-2xl text-magenta-500">
       O-Töne unserer Teilnehmer:innen
     </h3>


### PR DESCRIPTION
This PR changes the columns of the "In der Praxis" section. On mobile we now only have one column, so that both text and the image span the whole width.