### PR TITLE
fix(SAMS-78): Unify links btw module 4 and 8

### DIFF
--- a/src/modules/08.md
+++ b/src/modules/08.md
@@ -8,8 +8,8 @@ example: "Im Service Design Prozess des Zahnärztlichen Dienstes Berlin Neuköll
 hero_image_alt: Zwei Personen sprechen vor einer Menschenmenge, abstrakte Glühbirnen leuchten auf
 further_reading:
   - 
-    title: Service Design beim Zahnärztlichen Dienst Neukölln
-    description: ifaf Forschungsprojekt
+    title: Zahnärztlicher Dienst Berlin Neukölln
+    description: Dokumentation eines Forschungsprojekts zu Service Design in der öffentlichen Verwaltung
     link: https://www.publicservicedesign-berlin.org/
 ---
 


### PR DESCRIPTION
This PR uses the description and name of the link "Zahnärztlicher Dienst Berlin Neukölln" of module 4 also in module 8.